### PR TITLE
[Refactoring] 헤더 UI 수정, 탈퇴 회원 데이터 관리 UI 수정 + API 수정

### DIFF
--- a/src/apis/AdminAPI.js
+++ b/src/apis/AdminAPI.js
@@ -1,7 +1,7 @@
 import Swal from 'sweetalert2';
 import axios from "axios";
 import { jwtDecode } from 'jwt-decode';
-import { deleteDeleteVoice, getExpVoice } from '../modules/AdminModule';
+import { getExpVoice, posdtDeleteVoice } from '../modules/AdminModule';
 
 export function expiredVoiceAPI(){
     const requestURL = 'http://localhost:8001/expVoice';
@@ -10,7 +10,7 @@ export function expiredVoiceAPI(){
         await axios.get(requestURL)
             .then(function (response) {
                 console.log('[AdminAPI] expiredVoiceAPI RESPONSE : ', response);
-                if(response.status === 200) {
+                if(response.status == 200) {
                     dispatch(getExpVoice(response.data));
                 }
             })
@@ -21,14 +21,15 @@ export function expiredVoiceAPI(){
 }
 
 export function deleteVoiceAPI(voiceId){
-    const requestURL = `http://localhost:8001/deleteVoice/${voiceId}`
-
+    const requestURL = 'http://localhost:8002/deleteVoice';
+    console.log('[AdminAPI] deleteVoiceAPI voiceId : ', voiceId)
+    const body = { voiceId: voiceId };
     return async (dispatch, getState) => {
-        await axios.delete(requestURL)
+        await axios.post(requestURL, body)
             .then(function (response) {
                 console.log('[AdminAPI] deleteVoiceAPI RESPONSE : ', response);
                 if(response.status === 200){
-                    dispatch(deleteDeleteVoice(response.data));
+                    dispatch(posdtDeleteVoice(response.data));
                     Swal.fire({
                         icon: 'success',
                         title: "삭제 완료",
@@ -41,11 +42,11 @@ export function deleteVoiceAPI(voiceId){
                 }
             })
             .catch(function (error) {
-                console.error('AdminAPI expiredVoiceAPI 에러 발생 : ', error);
+                console.error('AdminAPI deleteVoiceAPI 에러 발생 : ', error);
                 Swal.fire({
                     icon: 'error',
                     title: "보이스아이디 삭제 중 오류 발생",
-                    text: error.response.data
+                    text: error.response.message
                 }).then(result => {
                     if(result.isConfirmed){
                         window.location.reload();;

--- a/src/components/common/Header.js
+++ b/src/components/common/Header.js
@@ -93,21 +93,14 @@ function Header() {
                     { user && user.userRole == "admin" ? (
                         <div className="mainMenuBox">
                             <ul className="mainMenu">
-                                <li onMouseEnter={() => handleMouseEnter('userInfo')} onMouseLeave={() => handleMouseLeave('userInfo')}>
-                                    <p>회원 정보 관리</p>
-                                    {subMenuStates.userInfo && (
-                                        <ul className="subMenu">
-                                            <li><a href="/userInfo">회원 정보 관리</a></li>
-                                        </ul>
-                                    )}
+                                <li>
+                                    <a href="/Make">새 동화 만들기</a>
                                 </li>
-                                <li onMouseEnter={() => handleMouseEnter('userService')} onMouseLeave={() => handleMouseLeave('userService')}>
-                                    <p>고객 문의 관리</p>
-                                    {subMenuStates.userService && (
-                                        <ul className="subMenu">
-                                            <li><a href="/CustomerService">고객 문의 관리</a></li>
-                                        </ul>
-                                    )}
+                                <li>
+                                    <a href="/userInfo">회원 정보 관리</a>
+                                </li>
+                                <li>
+                                    <a href="/CustomerService">고객 문의 관리</a>
                                 </li>
                             </ul>
                         </div>
@@ -124,7 +117,7 @@ function Header() {
                                         )}
                                     </li>
                                     <li onMouseEnter={() => handleMouseEnter('voice')} onMouseLeave={() => handleMouseLeave('voice')}>
-                                        <p>목소리</p>
+                                        <p>목소리 등록</p>
                                         {subMenuStates.voice && (
                                             <ul className="subMenu">
                                                 <li><a href="/voice">목소리 등록</a></li>
@@ -136,6 +129,7 @@ function Header() {
                                         {subMenuStates.myPage && (
                                             <ul className="subMenu">
                                                 <li><a href="/Info">내 정보</a></li>
+                                                <li><a href="/CustomerService">문의하기</a></li>
                                             </ul>
                                         )}
                                     </li>

--- a/src/modules/AdminModule.js
+++ b/src/modules/AdminModule.js
@@ -13,14 +13,14 @@ const adminSlice = createSlice({
         // 내부적으로 Redux Toolkit은 Immer를 사용하기 때문에 상태를 직접 변형할 수 있습니다
         return action.payload;
       },
-      deleteDeleteVoice: (state, action) => {
+      posdtDeleteVoice: (state, action) => {
         return action.payload;
       },
     },
 });
 
 // 생성된 Redux 액션 생성자를 내보냅니다
-export const { getExpVoice, deleteDeleteVoice } = adminSlice.actions;
+export const { getExpVoice, posdtDeleteVoice } = adminSlice.actions;
 
 // createSlice에 의해 자동 생성된 리듀서를 내보냅니다
 export default adminSlice.reducer;

--- a/src/pages/admin/UserInfo.js
+++ b/src/pages/admin/UserInfo.js
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { deleteVoiceAPI, expiredVoiceAPI } from '../../apis/AdminAPI';
 import Swal from 'sweetalert2';
 import "../../styles/admin/admin.css"
+import "../../styles/common/Common.css";
 
 function UserInfo() {
     
@@ -32,6 +33,7 @@ function UserInfo() {
             icon: 'question',
             title: "삭제하시겠습니까?",
             confirmButtonText: "확인",
+            showDenyButton: true,
             denyButtonText: "취소"
         }).then(result => {
             if(result.isConfirmed){
@@ -41,45 +43,52 @@ function UserInfo() {
     }
 
     return (
-        <div>
-            <p>회원 정보 관리</p>
-            <h4>탈퇴 회원 보이스아이디 삭제</h4>
-            <table>
-                <colgroup>
-                    <col width="30%"/>
-                    <col width="30%"/>
-                    <col width="40%"/>
-                </colgroup>
-                <thead>
-                    <tr>
-                        <th>NO</th>
-                        <th>VOICE_ID</th>
-                        <th>DELETE</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {expVoices && expVoices.length > 0 ? (
-                        expVoices.slice(startIndex, endIndex).map(
-                            (voices, index) => (
-                                <tr key={voices.no}>
-                                    <td>{index + 1}</td>
-                                    <td>{voices.voiceId}</td>
-                                    <td>
-                                        <button onClick={() => deleteVoiceHandler(voices.voiceId)}>아이디 삭제</button>
-                                    </td>
-                                </tr>
-                        ))
-                    ):(
+        <div className='userInfoBox'>
+            <p className='userInfoTitle'>회원 정보 관리</p>
+            <h2 className='deleteTitle'>탈퇴 회원 보이스 데이터 삭제</h2>
+            <br/>
+            <div className='userInfoTable'>
+                <div className='userInfoTxt'>
+                    <a>만료 보이스 데이터 누적 수 : {expVoices[0]?.no}</a>
+                    <a>삭제 처리된 데이터 총 건수 : {expVoices[0]?.no - expVoices?.length}</a>
+                </div>
+                <table>
+                    <colgroup>
+                        <col width="30%"/>
+                        <col width="30%"/>
+                        <col width="40%"/>
+                    </colgroup>
+                    <thead>
                         <tr>
-                            <td colSpan="3">
-                                <h6>내역이 존재하지 않습니다.</h6>
-                            </td>
+                            <th>NO</th>
+                            <th>VOICE_ID</th>
+                            <th>DELETE</th>
                         </tr>
-                    )}
-                </tbody>
-            </table>
+                    </thead>
+                    <tbody>
+                        {expVoices && expVoices.length > 0 ? (
+                            expVoices.slice(startIndex, endIndex).map(
+                                (voices, index) => (
+                                    <tr key={voices.no}>
+                                        <td>{totalItems - (startIndex + index)}</td>
+                                        <td>{voices.voiceId.slice(0, -5) + "*****"}</td>
+                                        <td>
+                                            <button className='deleteBtn' onClick={() => deleteVoiceHandler(voices.voiceId)}>아이디 삭제</button>
+                                        </td>
+                                    </tr>
+                            ))
+                        ):(
+                            <tr>
+                                <td colSpan="3" style={{textAlign: 'center'}}>
+                                    <h6>내역이 존재하지 않습니다.</h6>
+                                </td>
+                            </tr>
+                        )}
+                    </tbody>
+                </table>
+            </div>
             <ul className='pagination'>
-                <li className='icon' onClick={() => handlePageChange(currentPage -1)}></li>
+                <li className='icon' onClick={() => handlePageChange(currentPage -1)}><a>&lt;</a></li>
                 {Array.from({ length: totalPages }, (_, index) => (
                     <li
                         key={index}
@@ -90,7 +99,7 @@ function UserInfo() {
                         </a>
                     </li>
                 ))}
-                <li onClick={() => handlePageChange(currentPage +1)}></li>
+                <li onClick={() => handlePageChange(currentPage +1)}><a>&gt;</a></li>
             </ul>
         </div>
     );

--- a/src/styles/admin/admin.css
+++ b/src/styles/admin/admin.css
@@ -1,7 +1,122 @@
 table {
     width: 100%;
+    border-collapse: collapse;
+    border-spacing: 0;
+    border: solid 1px #cccccc;
+    border-left: 0;
+    border-right: 0;
+    text-align: center;
 }
 
-table thead, tbody{
+thead {
+    border-bottom: solid 2px #9baf00;
+}
+
+th, td {
+    padding: 1rem;
+    border: solid 1px #cccccc;
+    border-left: 0;
+    border-right: 0;
+}
+
+th {
+    font-weight: 700;
+}
+
+tr:nth-child(even) {
+    background-color: #f7f7f7;
+}
+
+tr:nth-child(even):hover {
+    background-color: #ebebeb;
+}
+
+.userInfoBox {
+    height: auto;
+}
+
+.userInfoTitle {
+    font-size: 32px;
+    color: #824600;
+    margin-left: 300px;
+    margin-top: 50px;
+}
+
+.deleteTitle {
     text-align: center;
+    color: #9baf00;
+}
+
+.userInfoTable {
+    width: 70%;
+    margin: auto;
+}
+
+.userInfoTxt {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+}
+
+.deleteBtn {
+    padding: 5px 30px;
+    border-radius: 5px;
+    outline: none;
+    border: solid 1px #C7302B;
+    background-color: #C7302B;
+    color: white;
+    font-size: 15px;
+}
+
+.deleteBtn:hover {
+    border: solid 1px #a9221d;
+    background-color: #a9221d;
+}
+
+.pagination {
+    width: 70%;
+    margin: auto;
+    margin-top: 1rem;
+    margin-bottom: 1rem;
+    gap: .25rem
+}
+  
+.pagination,
+.pagination li a {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+  
+.pagination li {
+    background-color: white;
+    list-style: none;
+    cursor: pointer;
+}
+  
+.pagination li a {
+    text-decoration: none;
+    color: #9baf00;
+    height: 40px;
+    width: 40px;
+    font-size: .9rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: .25rem;
+    border: 1px solid #9baf00;
+}
+  
+.pagination li:last-child a {
+    border-right-width: 1px;
+}
+  
+.pagination li a.active,
+.pagination li a:hover,
+.pagination li a:focus,
+.pagination li a:active {
+    background-color: #9baf00;
+    border: 1px solid #9baf00;
+    color: white;
 }

--- a/src/styles/mains/Header.css
+++ b/src/styles/mains/Header.css
@@ -107,5 +107,3 @@
     border-bottom: none;
 }
 
-
-

--- a/src/styles/voice/Voice.css
+++ b/src/styles/voice/Voice.css
@@ -112,6 +112,7 @@
 .recordMsg{
     text-align: center;
     font-size: 15px;
+    height: 15px;
     color: rgb(0, 200, 0);
 }
 


### PR DESCRIPTION
## 작업 분류
* * *
- 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
* * *
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경변수, 빌드 관련 코드 업데이트
- [x] 기타 수정

## 개요
* * *
- 헤더 UI 수정
- 탈퇴 회원 데이터 관리 UI 수정 + API 수정

## 변경 사항
* * *
- 관리자 헤더는 서브메뉴가 필요하지 않아 서브메뉴를 지웠습니다.(헤더 메뉴 클릭 시 바로 이동)
- 탈퇴 회원 데이터 관리 페이지 UI를 완성했으며 API 요청을 자바(8001)에서 파이썬(8002)로 변경했습니다.

## 코드 리뷰시 참고 사항
* * *


## 테스트 결과
* * *
- ![image](https://github.com/Re-Spring/DoFront/assets/140992400/85f6ff58-437d-4687-b04a-873c56fc677d)


## 요청 사항
* * *
